### PR TITLE
use Google servers for reCAPTCHA and make https sites work

### DIFF
--- a/include/thirdparty/recaptchalib.php
+++ b/include/thirdparty/recaptchalib.php
@@ -35,9 +35,8 @@
 /**
  * The reCAPTCHA server URL's
  */
-define("RECAPTCHA_API_SERVER", "http://api.recaptcha.net");
-define("RECAPTCHA_API_SECURE_SERVER", "https://api-secure.recaptcha.net");
-define("RECAPTCHA_VERIFY_SERVER", "api-verify.recaptcha.net");
+define("RECAPTCHA_API_SERVER", "//www.google.com/recaptcha/api");
+define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
 
 /**
  * Encodes the given data into a query string format
@@ -109,11 +108,7 @@ function recaptcha_get_html ($pubkey, $error = null, $use_ssl = false)
 		die ("To use reCAPTCHA you must get an API key from <a href='http://recaptcha.net/api/getkey'>http://recaptcha.net/api/getkey</a>");
 	}
 	
-	if ($use_ssl) {
-                $server = RECAPTCHA_API_SECURE_SERVER;
-        } else {
-                $server = RECAPTCHA_API_SERVER;
-        }
+        $server = RECAPTCHA_API_SERVER;
 
         $errorpart = "";
         if ($error) {
@@ -169,7 +164,7 @@ function recaptcha_check_answer ($privkey, $remoteip, $challenge, $response, $ex
                 return $recaptcha_response;
         }
 
-        $response = _recaptcha_http_post (RECAPTCHA_VERIFY_SERVER, "/verify",
+        $response = _recaptcha_http_post (RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/verify",
                                           array (
                                                  'privatekey' => $privkey,
                                                  'remoteip' => $remoteip,


### PR DESCRIPTION
- reCAPTCHA belongs to Google since a long time ago
- it didn't work on https sites
- the decision whether to use SSL should be left to the browser, using a "//www.google.com" URL