### PR TITLE
entirely visible thumbs in gallery inline editor

### DIFF
--- a/include/css/inline_image.css
+++ b/include/css/inline_image.css
@@ -73,10 +73,8 @@
 	display:inline-block;
 	margin:0;
 	padding:0;
-	max-width:200px;
-	max-height:200px;
-	min-width:70px;
-	min-height:70px;
+	width:100%;
+	height:auto;
 	background:#fff;
 	}
 


### PR DESCRIPTION
Using width:100%; height:auto; to always scale the thumbs to fit the container and make them better recognizable regardless of their px size.
Not part of this proposal: Maybe also add a basename($image_path) as title attribute to the surrounding <a> tag to hover the filename - sometimes the filename is decisive, especially when different sized of the same image are present in the same directory (?).