### PR TITLE
avoid error maximum function nesting level of '250' reached Update Child_Thumbnails.php

### DIFF
--- a/addons/--Child_Thumbnails/Child_Thumbnails.php
+++ b/addons/--Child_Thumbnails/Child_Thumbnails.php
@@ -54,7 +54,12 @@ class Child_Thumbnails{
 		if( !is_array($file_sections) ){
 			return;
 		}
-
+		
+		foreach($file_sections as $key=>$val){
+		if($val['type']=='include')
+		unset($file_sections[$key]) ;
+		}
+		
 		//get the image
 		$content = section_content::Render($file_sections,$title,$file_stats);
 		$img_pos = strpos($content,'<img');


### PR DESCRIPTION
avoid error maximum function nesting level of '250' reached
When page have little bit deeper tree like  - test(childs pages= test1 test2 test3)  test3(childs pages= test4 test5 test6)
and plugin is placed on "test" page and "test3" page.
test page throws error Maximum function nesting level of '250' reached, aborting! in include\tool\Plugins.php   [line] => (integer)132    
so need not to render include secion.