### PR TITLE
add 'message_sent' class to span

### DIFF
--- a/include/special/special_contact.php
+++ b/include/special/special_contact.php
@@ -221,7 +221,7 @@ class special_contact_gadget{
 		}
 
 			if( $this->sent ){
-				echo gpOutput::ReturnText('message_sent');
+				echo gpOutput::ReturnText('message_sent','%s','message_sent');
 			}else{
 				echo '<input type="hidden" name="cmd" value="gp_send_message" />';
 


### PR DESCRIPTION
Although we can target the 'sent' message via '.contactform textarea+span', it's clearer to give it a distinct classname