### PR TITLE
replace contactform textarea height to allow reisze

### DIFF
--- a/include/css/additional.css
+++ b/include/css/additional.css
@@ -112,7 +112,8 @@ body .messages a{
 	width:60%;
 }
 .contactform textarea{
-	height:180px!important;
+	min-height:180px;
+	max-height:180px;
 	width:98%;
 }
 .contactform .submit{


### PR DESCRIPTION
the height:180px!important rule prevents using CSS resize. height cannot be neutralized in theme css, min-height and max-height can.