### PR TITLE
 add classes for "Publish Draft" and related msg links

### DIFF
--- a/include/tool/editing_page.php
+++ b/include/tool/editing_page.php
@@ -141,10 +141,11 @@ class editing_page extends display{
 		global $langmessage;
 
 		if( $this->draft_exists ){
-			$message	.= ' &nbsp; ';
-			$message	.= common::Link($this->title,$langmessage['Publish Draft'],'cmd=PublishDraft',array('data-cmd'=>'creq'));
-			$message	.= ' &nbsp; '.common::Link($this->title,$langmessage['Discard Draft'],'cmd=DiscardDraft',array('data-cmd'=>'creq'));
-			$message	.= ' &nbsp; '.common::Link($this->title,$langmessage['Revision History'],'cmd=ViewHistory',array('data-cmd'=>'gpabox'));
+			$message	.= '&nbsp; <span style="white-space:nowrap;">';
+			$message	.= common::Link($this->title,$langmessage['Publish Draft'],'cmd=PublishDraft',array('data-cmd'=>'creq', 'class'=>'msg_publish_draft'));
+			$message	.= common::Link($this->title,$langmessage['Discard Draft'],'cmd=DiscardDraft',array('data-cmd'=>'creq', 'class'=>'msg_discard_draft'));
+			$message	.= common::Link($this->title,$langmessage['Revision History'],'cmd=ViewHistory',array('data-cmd'=>'gpabox','class'=>'msg_view_history'));
+			$message	.= '</span>';
 		}
 
 		msg($message);


### PR DESCRIPTION
...and wrap the links inside a span with white-space:nowrap, so they go into a separate line if there is not enough space.
E.g. needed for german language where "Your changes were saved.   Publish Draft    Discard Draft   Revision History" translates to 
"Ihre Änderungen wurden gespeichert.  Entwurf publizieren   Entwurf verwerfen   Versionsverlauf", which otherwise causes a line break before "Versionsverlauf". This will likely also apply to some other languages.
Proposal for changes to additional.css will follow shortly.